### PR TITLE
Fix issue #27 where first enter in chat creates new line

### DIFF
--- a/client/src/components/Chat/index.js
+++ b/client/src/components/Chat/index.js
@@ -31,9 +31,13 @@ function Chat() {
         setIsShiftDown(true);
       }
 
-      if (keyCode === ENTER_CODE && !isShiftDown && value && sendMessage) {
+      if (keyCode === ENTER_CODE && !isShiftDown && sendMessage) {
         e.preventDefault();
-        sendMessage(value);
+
+        if (value) {
+          sendMessage(value);
+        }
+
         setValue('');
         bottomRef.current.scrollIntoView({
           behavior: 'smooth',


### PR DESCRIPTION
Fixes the bug always allowing `e.preventDefault()` to run even when `value` is falsey, yet still only call `sendMessage` if `value` is truthy.

Closes #27 