### PR TITLE
Typo in ECR repo name. This finally fixes the docker image upload.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ workflows:
           name: build-server-image
           context: AWS Prod
           path: ./server
-          repo: poker-app
+          repo: poker_app
           tag: $CIRCLE_SHA1
           filters:
             branches:


### PR DESCRIPTION
Closes #37 