### PR TITLE
Feature/redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,31 @@
 version: "3.8"
 services:
+  redis:
+    image: redis:6.0.6
+    expose:
+      - 6379
   server:
     build: server/
     volumes:
       - ./server:/app
       - /app/node_modules
     ports:
-      - 8080:8080
+      - 4000-4001:8080
     environment:
       - NODE_ENV=development
+    depends_on:
+      - redis
+  haproxy:
+    image: eeacms/haproxy:1.8-1.5
+    depends_on:
+      - server
+    ports:
+      - 8080:5000
+      - 8081:1936
+    environment:
+      BACKENDS: server
+      DNS_ENABLED: "true"
+      LOG_LEVEL: info
   client:
     stdin_open: true
     build: client/
@@ -20,4 +37,4 @@ services:
       - 3000:3000
       - 3001:3001
     depends_on:
-      - server
+      - haproxy

--- a/infrastructure/app/application.tf
+++ b/infrastructure/app/application.tf
@@ -71,8 +71,8 @@ resource "aws_elastic_beanstalk_environment" "prod_env" {
 
   setting {
     namespace = "aws:ec2:vpc"
-    name = "AssociatePublicIpAddress"
-    value = true
+    name      = "AssociatePublicIpAddress"
+    value     = true
   }
 
   setting {
@@ -114,9 +114,9 @@ resource "aws_s3_bucket" "app_version_bucket" {
 }
 
 resource "aws_s3_bucket_object" "app_version_bundle" {
-  bucket  = aws_s3_bucket.app_version_bucket.id
-  key     = "Dockerrun.aws.json"
-  tags    = local.tags
+  bucket = aws_s3_bucket.app_version_bucket.id
+  key    = "Dockerrun.aws.json"
+  tags   = local.tags
   content = templatefile("${path.module}/templates/Dockerrun.aws.json.tmpl", {
     repo_url = var.repo_url
   })

--- a/infrastructure/app/cache.tf
+++ b/infrastructure/app/cache.tf
@@ -1,0 +1,17 @@
+resource "aws_elasticache_subnet_group" "redis_subnet_group" {
+  name       = "poker-app-cache-subnet-group"
+  subnet_ids = module.vpc.elasticache_subnets
+}
+
+resource "aws_elasticache_replication_group" "redis_group" {
+  engine                        = "redis"
+  engine_version                = "5.0.3"
+  automatic_failover_enabled    = true
+  availability_zones            = module.vpc.azs
+  replication_group_id          = "poker-app-cache-replication-group"
+  replication_group_description = "Redis cluster for poker app"
+  node_type                     = "cache.t2.micro"
+  number_cache_clusters         = 2
+  parameter_group_name          = "default.redis5.0"
+  port                          = 6379
+}

--- a/infrastructure/app/outputs.tf
+++ b/infrastructure/app/outputs.tf
@@ -1,3 +1,7 @@
 output "website_endpoint" {
-  value = "${aws_s3_bucket.app_bucket.website_endpoint}"
+  value = aws_s3_bucket.app_bucket.website_endpoint
+}
+
+output "redis_endpoint" {
+  value = aws_elasticache_replication_group.redis_group.primary_endpoint_address
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "server",
+  "name": "holdem_server",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -2705,6 +2705,11 @@
       "requires": {
         "is-obj": "^1.0.0"
       }
+    },
+    "double-ended-queue": {
+      "version": "2.1.0-0",
+      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -6762,6 +6767,11 @@
       "resolved": "https://packages.atlassian.com/api/npm/npm-remote/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU="
     },
+    "notepack.io": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-2.1.3.tgz",
+      "integrity": "sha512-AgSt+cP5XMooho1Ppn8NB3FFaVWefV+qZoZncYTUSch2GAEwlYLcIIbT5YVkMlFeNHnfwOvc4HDlbvrB5BRxXA=="
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://packages.atlassian.com/api/npm/npm-remote/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -7672,6 +7682,26 @@
       "integrity": "sha1-c3esQptuH9WZ3DjQjtlC0Ne+uGY=",
       "dev": true
     },
+    "redis": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "requires": {
+        "double-ended-queue": "^2.1.0-0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.6.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.6.0.tgz",
+      "integrity": "sha512-2jnZ0IkjZxvguITjFTrGiLyzQZcTvaw8DAaCXxZq/dsHXz7KfMQ3OUJy7Tz9vnRtZRVz6VRCPDvruvU8Ts44wQ=="
+    },
+    "redis-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+      "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://packages.atlassian.com/api/npm/npm-remote/regex-not/-/regex-not-1.0.2.tgz",
@@ -8523,6 +8553,33 @@
         }
       }
     },
+    "socket.io-redis": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/socket.io-redis/-/socket.io-redis-5.3.0.tgz",
+      "integrity": "sha512-w2EqyGdw3oXzd1MY4sVIg2rYVooDI5sSwel8DOt38sTgaJuuXQSC847x38FvLSn2Rt6MAcdLhiNw/FqjzeC4RQ==",
+      "requires": {
+        "debug": "~4.1.0",
+        "notepack.io": "~2.1.2",
+        "redis": "~2.8.0",
+        "socket.io-adapter": "~1.1.0",
+        "uid2": "0.0.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "socketio-jwt": {
       "version": "4.5.0",
       "resolved": "https://packages.atlassian.com/api/npm/npm-remote/socketio-jwt/-/socketio-jwt-4.5.0.tgz",
@@ -9200,6 +9257,11 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
     },
     "undefsafe": {
       "version": "2.0.3",

--- a/server/package.json
+++ b/server/package.json
@@ -20,6 +20,7 @@
     "jsonwebtoken": "^8.5.1",
     "pm2": "^4.4.0",
     "socket.io": "^2.3.0",
+    "socket.io-redis": "^5.3.0",
     "socketio-jwt": "^4.5.0",
     "uuid": "^7.0.2"
   },

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -3,6 +3,10 @@ module.exports = {
   auth: {
     privateKey: 'developmentkey',
   },
+  redis: {
+    host: 'redis',
+    port: 6379
+  },
   socket: {
     pingInterval: 10000,
     pingTimeout: 5000,

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   redis: {
     host: 'redis',
-    port: 6379
+    port: 6379,
   },
   socket: {
     pingInterval: 10000,

--- a/server/src/socket/index.js
+++ b/server/src/socket/index.js
@@ -1,4 +1,5 @@
 const IO = require('socket.io');
+const redisAdapter = require('socket.io-redis');
 const config = require('../config');
 const Auth = require('./auth');
 const Game = require('./game');
@@ -19,6 +20,7 @@ function Socket(server) {
     pingTimeout: config.socket.pingTimeout,
   });
 
+  io.adapter(redisAdapter(config.redis));
   io.use(Auth.middleware);
 
   modules.forEach((module) => {

--- a/server/src/socket/index.js
+++ b/server/src/socket/index.js
@@ -20,7 +20,11 @@ function Socket(server) {
     pingTimeout: config.socket.pingTimeout,
   });
 
-  io.adapter(redisAdapter(config.redis));
+  if (process.env.NODE_ENV !== 'test') {
+    // Figure out a way to mock redis in tests
+    io.adapter(redisAdapter(config.redis));
+  }
+
   io.use(Auth.middleware);
 
   modules.forEach((module) => {


### PR DESCRIPTION
Fixes #7 
(^If your PR fixes an issue)

### Background

In order to scale the server to be a distributed system, we need inner process communication. Socket.io is stateful and has long run connections, and to maintain state across servers, you can add a redis adapters so the library talks through redis. This allows you to scale to as many nodes as you want.

### Proposed Changes

Technical changes:

  - Configure simple redis cluster in `/infrastructure/app` to stand up in private subnets of VPC
  - Add server distribution and redis to local dev in `docker-compose.yml` to simulate distribution locally

### Future work

  - Provide production redis url to server's config