### PR TITLE
Fixup bucket name for dns resolution

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,8 +1,8 @@
 import { get, post, patch } from 'axios';
 import config from './config';
 
-const userRoute = `${config.serverUrl}/api/users`;
-const gameRoute = `${config.serverUrl}/api/games`;
+const userRoute = `${config.serverUrl}/users`;
+const gameRoute = `${config.serverUrl}/games`;
 
 const opts = (token) => ({
   headers: {

--- a/infrastructure/app/client_bucket.tf
+++ b/infrastructure/app/client_bucket.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "app_bucket" {
-  bucket        = "poker-frontend-app"
+  bucket        = "www.holdemhounds.com"
   acl           = "public-read"
   force_destroy = true
   policy        = file("${path.module}/policies/bucket_policy.json")

--- a/server/src/api/index.test.js
+++ b/server/src/api/index.test.js
@@ -4,7 +4,7 @@ const api = require('./index');
 describe('API', () => {
   it('pings successfully', () => (
     request(api)
-      .get('/api/ping')
+      .get('/ping')
       .expect(200)
   ));
 });

--- a/server/src/rest/index.js
+++ b/server/src/rest/index.js
@@ -5,19 +5,17 @@ const Users = require('./users');
 const Games = require('./games');
 
 const api = express();
-const router = express.Router();
 
 // Middleware
-router.use(cors());
-router.use(express.json());
+api.use(cors());
+api.use(express.json());
 
 // Routes
-router.get('/ping', (req, res) => res.sendStatus(200));
-router.use('/users', Users.router);
-router.use('/games', Games.router);
+api.get('/ping', (req, res) => res.sendStatus(200));
+api.use('/users', Users.router);
+api.use('/games', Games.router);
 
 // Error Middleware
-router.use(Errors.middleware);
+api.use(Errors.middleware);
 
-api.use('/api', router);
 module.exports = api;


### PR DESCRIPTION
### Background

In order for DNS CNAME's to work with s3 buckets, the buckets have to have the same name as the host.

### Proposed Changes

Technical changes:

  - Delete old bucket name
  - Create new bucket with appropriate name
  - Have api watch `/` instead of `/api` since api will be at api subdomain

### Future work

What will we need to do later:

  - Move domain name and records into 53 from godaddy
