### PR TITLE
Fix bucket name in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
           at: .
       - aws-s3/sync:
           from: ./build
-          to: s3://poker-frontend-app
+          to: s3://www.holdemhounds.com
   deploy-server:
     executor: aws
     working_directory: ~/repo


### PR DESCRIPTION
### Background

We changed the bucket name but didn't update the name in the CI code so the client deploy failed.