### PR TITLE
Update README with docker-compose instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Hold'em</h1>
+<h1 align="center">Hold'em Hounds</h1>
 
 <p align="center">
   <a href="https://codeclimate.com/github/timhaley94/holdem/maintainability">
@@ -12,6 +12,22 @@
   </a>
 </p>
 
+Born of the pandemic, Hold'em Hounds is an (🚧 in development 🚧) poker app that's aiming to
+bring a fresh perspective to a crowded field of garish, clunky apps, desparate to suck you
+into microtransactions.
+
+## Product priorities
+
+Hold'em Hounds should be...
+
+- Multiplayer
+- Free to play
+- Real time
+- Account optional
+- Download optional
+- Not too serious
+- Beautiful
+
 ## Directory structure
 
 ```
@@ -24,32 +40,31 @@ holdem/
 
 ## Running locally
 
-Pull this repository using `git clone` and then verify you have
-[node.js](https://nodejs.org/en/) v12.16.2 installed. You can check using your node
-version using `node --version` in the terminal.
+While you you could set up each individual piece of the system locally (i.e. server, client, redis)
+the easiest way to run the project is through `docker-compose`. Make sure you have `docker` and
+`docker-compose` and then you can run `docker-compose up` in the root directory.
 
-### Launch the server
+Viola, http:localhost:3000.
 
-Change into the server directory with `cd server`. Install dependencies using
-`npm install`. Start the server using `npm run dev`. To verify it's running, check
-that `curl http://localhost:80/ping` returns a 200.
+The `docker-compose` configuration supports hot reloading, so once you have it running, your
+changes to `./client` and `./server` will be respected. However, if you ever need to force a
+rebuild: `docker-compose build`.
 
-### Launch the client
+### Run as a distributed system
 
-Change into the client directory with `cd ../client`. Install dependencies using
-`npm install`. Start the server using `npm run dev`. This will automatically open
-a browser tab.
+```sh
+docker-compose up --scale server=2
+```
 
-## Production builds
+### Run without logs
 
-Only the client needs to be "built" for production. You can create a production
-build of the client by running `npm run build` in the client directory. This
-creates a (gitignore'd) directory `client/build` which is the production build.
-
-Since static websites are just files, you can serve this directory for anywhere
-to "deploy" the website.
+```sh
+docker-compose up -d
+```
 
 ## Contributing
 
-Check Github issues for what to work on, fork this repository, and then open a
-pull request to get your code integrated.
+1. Read [our contributing guide](docs/CONTRIBUTING.md)
+2. Find a Github issues
+3. Fork this repository (if you aren't a collaborator)
+4. Open a pull request


### PR DESCRIPTION
Fixes #39

### Background

We changed the locally development environment to use `docker-compose` but didn't update the README.

