### PR TITLE
Fixup typos in Dockerrun.aws.json

### DIFF
--- a/infrastructure/app/templates/Dockerrun.aws.json.tmpl
+++ b/infrastructure/app/templates/Dockerrun.aws.json.tmpl
@@ -2,11 +2,11 @@
   "AWSEBDockerrunVersion": "1",
   "Image": {
     "Name": "${repo_url}:latest",
-    "Update": true
+    "Update": "true"
   },
   "Ports": [
     {
-      "ContainerPort": 8080
+      "ContainerPort": "8080"
     }
   ]
 }


### PR DESCRIPTION
### Background

Updates to the servers haven't be working. Apparently double quotes are required for this json file. Why? Idk pretty dumb interface, but what can you do.
