### PR TITLE
Fix up some things with docker to hopefully resolve prod issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ client/build
 
 # coverage
 **/coverage
+
+# misc
+**/temp

--- a/client/src/config.js
+++ b/client/src/config.js
@@ -1,6 +1,6 @@
 export default {
   serverUrl: (
-    process.env.NODE_ENV
+    process.env.NODE_ENV === 'production'
       ? 'http://api.holdemhounds.com'
       : 'http://localhost:8080'
   ),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
     volumes:
       - ./server:/app
       - /app/node_modules
-    ports:
-      - 4000-4001:8080
     environment:
       - NODE_ENV=development
     depends_on:
@@ -20,11 +18,14 @@ services:
     depends_on:
       - server
     ports:
-      - 8080:5000
+      - 8080:8080
       - 8081:1936
     environment:
+      FRONTEND_PORT: 8080
       BACKENDS: server
-      DNS_ENABLED: "true"
+      BACKENDS_PORT: 8080
+      DNS_ENABLED: "True"
+      HTTPCHK: GET /ping
       LOG_LEVEL: info
   client:
     stdin_open: true

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -12,4 +12,4 @@ COPY . .
 
 EXPOSE 8080
 
-CMD [ "bash", "./start.sh" ]
+CMD [ "npm", "start" ]

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "pm2 start ./src/index.js",
+    "start": "nodemon --watch src src/index.js",
     "dev": "nodemon --watch src src/index.js",
     "lint": "eslint src",
     "test": "jest src --coverage",

--- a/server/start.sh
+++ b/server/start.sh
@@ -1,5 +1,0 @@
-if [[ ${NODE_ENV} == "development" ]]; then
-  npm run dev;
-else
-  npm run start;
-fi


### PR DESCRIPTION
### Background

The server isn't running correctly in prod. Current theory is that because the start script for server was using `pm2`, which starts a background process, the container immediately dies. At least this is what happened when I pulled the latest server image locally. Additionally, we don't need `pm2` because there are beanstalk settings that will restart containers when the die.

### Proposed Changes

Technical changes:

  - No `pm2` or `start.sh` for server
  - Rearrange `docker-compose.yml` so that server ports are not exposed
  - Fix typo in client config

### Future work

What will we need to do later:

  - Make sure that new server image works as expected
  - Make sure that server containers actually start
  - Add beanstalk settings to automatically restart stopped containers
