### PR TITLE
Update client to use server's https endpoint

### DIFF
--- a/client/src/config.js
+++ b/client/src/config.js
@@ -1,7 +1,7 @@
 export default {
   serverUrl: (
     process.env.NODE_ENV === 'production'
-      ? 'http://api.holdemhounds.com'
+      ? 'https://api.holdemhounds.com'
       : 'http://localhost:8080'
   ),
   timUrl: 'https://timhaley.me',


### PR DESCRIPTION
Fixes #79 

### Background

Server https is working now. The client just needs to use it!