### PR TITLE
Fix up NACL for elasticache traffic

### DIFF
--- a/infrastructure/app/vpc.tf
+++ b/infrastructure/app/vpc.tf
@@ -14,8 +14,8 @@ locals {
       {
         rule_number = 100 + index(local.cidr_blocks.public, block)
         rule_action = "allow"
-        from_port   = 5000
-        to_port     = 5000
+        from_port   = 6379
+        to_port     = 6379
         protocol    = "tcp"
         cidr_block  = block
       }


### PR DESCRIPTION
### Background

Server is currently unable to talk to redis. I think this is only because of the wrong port being provided to the NACL for the elasticache subnets.