### PR TITLE
Switch load balancer type to alb to support websockets

### DIFF
--- a/infrastructure/app/application.tf
+++ b/infrastructure/app/application.tf
@@ -73,6 +73,12 @@ resource "aws_elastic_beanstalk_environment" "prod_env" {
     value     = aws_iam_role.ebs_service_role.name
   }
 
+  setting {
+    namespace = "aws:elasticbeanstalk:environment"
+    name      = "LoadBalancerType"
+    value     = "application"
+  }
+
   # Instance settings
   setting {
     namespace = "aws:ec2:vpc"


### PR DESCRIPTION
### Background

Currently websocket handshakes are failing. I believe this has to do with the fact that the classic load balancer, as configured, cannot support the websocket protocol. Allegedly, application load balancers can support this.