### PR TITLE
Introduce scripts.sh file

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,22 +50,19 @@ The `docker-compose` configuration supports hot reloading, so once you have it r
 changes to `./client` and `./server` will be respected. However, if you ever need to force a
 rebuild: `docker-compose build`.
 
-### Run as a distributed system
+### Scripts
 
+We have a `scripts.sh` file which takes a includes a number of subcommands. Some options are:
+- `up` stand up the system in the foreground (with logs)
+- `up_background` stand up the system in the background (no logs)
+- `down` bring the system down
+- `lint` run the linter against both the client and server source code
+- `test` run both the client and server test suites
+
+For example, if you wanted to start the app and then run the test suite, you'd run:
 ```sh
-docker-compose up --scale server=2
-```
-
-### Run without logs
-
-```sh
-docker-compose up -d
-```
-
-### Bring system down
-
-```sh
-docker-compose down
+./scripts.sh up_background
+./scripts.sh test
 ```
 
 ### High level docs

--- a/scripts.sh
+++ b/scripts.sh
@@ -1,0 +1,91 @@
+up () {
+  docker-compose up --scale server=2
+}
+
+up_background () {
+  docker-compose up -d --scale server=2
+}
+
+down () {
+  docker-compose down
+}
+
+status () {
+  docker-compose ps
+}
+
+lint_client () {
+  docker-compose exec client npm run lint
+}
+
+lint_server () {
+  docker-compose exec server npm run lint
+}
+
+lint () {
+  lint_client
+  lint_server
+}
+
+test_client () {
+  docker-compose exec client npm run test
+}
+
+test_client_watch () {
+  docker-compose exec client npm run test-watch
+}
+
+test_server () {
+  docker-compose exec server npm run test
+}
+
+test_server_watch () {
+  docker-compose exec server npm run test-watch
+}
+
+test () {
+  test_client
+  test_server
+}
+
+case "$1" in
+  up)
+    up
+    ;;
+  up_background)
+    up_background
+    ;;
+  down)
+    down
+    ;;
+  status)
+    status
+    ;;
+  lint_client)
+    lint_client
+    ;;
+  lint_server)
+    lint_server
+    ;;
+  lint)
+    lint
+    ;;
+  test_client)
+    test_client
+    ;;
+  test_server)
+    test_server
+    ;;
+  test_client_watch)
+    test_client_watch
+    ;;
+  test_server_watch)
+    test_server_watch
+    ;;
+  test)
+    test
+    ;;
+  *)
+    echo $"Basic usage: $0 {up|down|status|lint|test}"
+    exit 1
+esac


### PR DESCRIPTION
Fixes #106

### Background

Right now commands like `lint` and `test` do not have access to all the containers created by docker compose. Right now this doesn't matter, the only thing that server depends on is redis, however we are mocking redis. Once we introduce mongo though, we will want our scripts to actually have access to redis and mongo so that they can be true integration tests. You can achieve this using `docker-compose exec` although this is a lot for new developers to remember and is a lot to type. This PR introduces a `scripts.sh` which encapsulates these calls to `docker-compose exec`.

### Proposed Changes

Technical changes:
Introduces a `scripts.sh` which encapsulates all commands that will need to be run against the docker compose cluster.

### Future work

What will we need to do later:
Have CI use this file instead of calling the npm scripts directly.
